### PR TITLE
add @stop to stop infiltration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ variables.
 The following commands are special cased:
 - `@trace`: Print the current stack trace.
 - `@locals`: Print local variables.
+- `@stop`: Stop infiltrating at this `@infiltrate` spot.
 
-Exit this REPL mode with `Ctrl-D`.
+Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infiltrator.clear_stop()`.
 
 debug> @trace
 [1] f(::Int64) at none:4

--- a/test/Julia_f2_1.1.multiout
+++ b/test/Julia_f2_1.1.multiout
@@ -1,0 +1,24 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Hit `@infiltrate` in f(::Int64) at runtests.jl:7:
+|
+|debug> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Hit `@infiltrate` in f(::Int64) at runtests.jl:7:
+|
+|debug> @locals
+|- y::Array{Int64,1} = [1, 2, 3]
+|- x::Int64 = 2
+|
+|debug> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCC
+|
+|BBBBBBB

--- a/test/Julia_f2_1.2.multiout
+++ b/test/Julia_f2_1.2.multiout
@@ -1,0 +1,24 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Hit `@infiltrate` in f(::Int64) at runtests.jl:7:
+|
+|debug> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Hit `@infiltrate` in f(::Int64) at runtests.jl:7:
+|
+|debug> @locals
+|- y::Array{Int64,1} = [1, 2, 3]
+|- x::Int64 = 2
+|
+|debug> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCC
+|
+|BBBBBBB

--- a/test/Julia_f2_1.3.multiout
+++ b/test/Julia_f2_1.3.multiout
@@ -1,0 +1,24 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Hit `@infiltrate` in f(::Int64) at runtests.jl:7:
+|
+|debug> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Hit `@infiltrate` in f(::Int64) at runtests.jl:7:
+|
+|debug> @locals
+|- y::Array{Int64,1} = [1, 2, 3]
+|- x::Int64 = 2
+|
+|debug> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCC
+|
+|BBBBBBB

--- a/test/Julia_f2_1.4.multiout
+++ b/test/Julia_f2_1.4.multiout
@@ -1,0 +1,24 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Hit `@infiltrate` in f(::Int64) at runtests.jl:7:
+|
+|debug> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Hit `@infiltrate` in f(::Int64) at runtests.jl:7:
+|
+|debug> @locals
+|- y::Array{Int64,1} = [1, 2, 3]
+|- x::Int64 = 2
+|
+|debug> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCC
+|
+|BBBBBBB

--- a/test/Julia_f_1.1.multiout
+++ b/test/Julia_f_1.1.multiout
@@ -16,8 +16,10 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> 
 --------------------------------------------------
@@ -30,8 +32,10 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -44,14 +48,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::getfield(Main, Symbol("##3#6")){getfield(Main, Symbol("##4#7")),Array{Int
-|64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##26#30")),Array
+|{Int64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> 
 --------------------------------------------------
@@ -64,14 +70,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -84,14 +92,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::getfield(Main, Symbol("##3#6")){getfield(Main, Symbol("##4#7")),Array{Int
-|64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##26#30")),Array
+|{Int64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- y::Array{Int64,1} = [1, 2, 3]
@@ -108,14 +118,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -132,14 +144,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::getfield(Main, Symbol("##3#6")){getfield(Main, Symbol("##4#7")),Array{Int
-|64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##26#30")),Array
+|{Int64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- y::Array{Int64,1} = [1, 2, 3]
@@ -162,14 +176,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -192,14 +208,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::getfield(Main, Symbol("##3#6")){getfield(Main, Symbol("##4#7")),Array{Int
-|64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##26#30")),Array
+|{Int64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- y::Array{Int64,1} = [1, 2, 3]
@@ -225,14 +243,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -258,14 +278,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::getfield(Main, Symbol("##3#6")){getfield(Main, Symbol("##4#7")),Array{Int
-|64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##26#30")),Array
+|{Int64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- y::Array{Int64,1} = [1, 2, 3]
@@ -294,14 +316,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -318,5 +342,85 @@
 |
 |BBBBBBBCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Hit `@infiltrate` in f(::Int64) at runtests.jl:7:
+|
+|debug> ?
+|  Code entered is evaluated in the current function's module. Note that you cann
+|ot change local
+|  variables.
+|  The following commands are special cased:
+|    - `@trace`: Print the current stack trace.
+|    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
+|
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
+|
+|debug> @trace
+|[1] f(::Int64) at runtests.jl:7
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##26#30")),Array
+|{Int64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
+|
+|debug> @locals
+|- y::Array{Int64,1} = [1, 2, 3]
+|- x::Int64 = 2
+|
+|debug> x.*y
+|3-element Array{Int64,1}:
+| 2
+| 4
+| 6
+|
+|debug> foo
+|3
+|
+|debug> 0//0
+|ERROR: ArgumentError: invalid rational: zero(Int64)//zero(Int64)
+|
+|debug> @stop
+|
+|debug> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCC
+|CCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCC
+|
+|BBBBBBBCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCC
+|CC
+|CC
+|CC
+|
+|BBBBBBBCCC
+|C
+|
+|BBBBBBBCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCC
 |
 |BBBBBBB

--- a/test/Julia_f_1.2.multiout
+++ b/test/Julia_f_1.2.multiout
@@ -16,8 +16,10 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> 
 --------------------------------------------------
@@ -30,8 +32,10 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -44,14 +48,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::getfield(Main, Symbol("##3#6")){getfield(Main, Symbol("##4#7")),Array{Int
-|64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##26#30")),Array
+|{Int64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> 
 --------------------------------------------------
@@ -64,14 +70,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -84,14 +92,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::getfield(Main, Symbol("##3#6")){getfield(Main, Symbol("##4#7")),Array{Int
-|64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##26#30")),Array
+|{Int64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- y::Array{Int64,1} = [1, 2, 3]
@@ -108,14 +118,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -132,14 +144,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::getfield(Main, Symbol("##3#6")){getfield(Main, Symbol("##4#7")),Array{Int
-|64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##26#30")),Array
+|{Int64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- y::Array{Int64,1} = [1, 2, 3]
@@ -162,14 +176,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -192,14 +208,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::getfield(Main, Symbol("##3#6")){getfield(Main, Symbol("##4#7")),Array{Int
-|64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##26#30")),Array
+|{Int64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- y::Array{Int64,1} = [1, 2, 3]
@@ -225,14 +243,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -258,14 +278,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::getfield(Main, Symbol("##3#6")){getfield(Main, Symbol("##4#7")),Array{Int
-|64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##26#30")),Array
+|{Int64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- y::Array{Int64,1} = [1, 2, 3]
@@ -294,14 +316,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -318,5 +342,85 @@
 |
 |BBBBBBBCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Hit `@infiltrate` in f(::Int64) at runtests.jl:7:
+|
+|debug> ?
+|  Code entered is evaluated in the current function's module. Note that you cann
+|ot change local
+|  variables.
+|  The following commands are special cased:
+|    - `@trace`: Print the current stack trace.
+|    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
+|
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
+|
+|debug> @trace
+|[1] f(::Int64) at runtests.jl:7
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##26#30")),Array
+|{Int64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
+|
+|debug> @locals
+|- y::Array{Int64,1} = [1, 2, 3]
+|- x::Int64 = 2
+|
+|debug> x.*y
+|3-element Array{Int64,1}:
+| 2
+| 4
+| 6
+|
+|debug> foo
+|3
+|
+|debug> 0//0
+|ERROR: ArgumentError: invalid rational: zero(Int64)//zero(Int64)
+|
+|debug> @stop
+|
+|debug> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCC
+|CCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCC
+|
+|BBBBBBBCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCC
+|CC
+|CC
+|CC
+|
+|BBBBBBBCCC
+|C
+|
+|BBBBBBBCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCC
 |
 |BBBBBBB

--- a/test/Julia_f_1.3.multiout
+++ b/test/Julia_f_1.3.multiout
@@ -16,8 +16,10 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> 
 --------------------------------------------------
@@ -30,8 +32,10 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -44,14 +48,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::var"##3#6"{var"##4#7",Array{Int64,1}})(::TerminalRegressionTests.Emulated
-|Terminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##26#30")),Array
+|{Int64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> 
 --------------------------------------------------
@@ -64,14 +70,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -84,14 +92,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::var"##3#6"{var"##4#7",Array{Int64,1}})(::TerminalRegressionTests.Emulated
-|Terminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##26#30")),Array
+|{Int64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- y::Array{Int64,1} = [1, 2, 3]
@@ -108,14 +118,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -132,14 +144,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::var"##3#6"{var"##4#7",Array{Int64,1}})(::TerminalRegressionTests.Emulated
-|Terminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##26#30")),Array
+|{Int64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- y::Array{Int64,1} = [1, 2, 3]
@@ -162,14 +176,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -192,14 +208,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::var"##3#6"{var"##4#7",Array{Int64,1}})(::TerminalRegressionTests.Emulated
-|Terminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##26#30")),Array
+|{Int64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- y::Array{Int64,1} = [1, 2, 3]
@@ -225,14 +243,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -258,14 +278,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::var"##3#6"{var"##4#7",Array{Int64,1}})(::TerminalRegressionTests.Emulated
-|Terminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##26#30")),Array
+|{Int64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- y::Array{Int64,1} = [1, 2, 3]
@@ -294,14 +316,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -318,5 +342,85 @@
 |
 |BBBBBBBCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Hit `@infiltrate` in f(::Int64) at runtests.jl:7:
+|
+|debug> ?
+|  Code entered is evaluated in the current function's module. Note that you cann
+|ot change local
+|  variables.
+|  The following commands are special cased:
+|    - `@trace`: Print the current stack trace.
+|    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
+|
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
+|
+|debug> @trace
+|[1] f(::Int64) at runtests.jl:7
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##26#30")),Array
+|{Int64,1}})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
+|
+|debug> @locals
+|- y::Array{Int64,1} = [1, 2, 3]
+|- x::Int64 = 2
+|
+|debug> x.*y
+|3-element Array{Int64,1}:
+| 2
+| 4
+| 6
+|
+|debug> foo
+|3
+|
+|debug> 0//0
+|ERROR: ArgumentError: invalid rational: zero(Int64)//zero(Int64)
+|
+|debug> @stop
+|
+|debug> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCC
+|CCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCC
+|
+|BBBBBBBCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCC
+|CC
+|CC
+|CC
+|
+|BBBBBBBCCC
+|C
+|
+|BBBBBBBCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCC
 |
 |BBBBBBB

--- a/test/Julia_f_1.4.multiout
+++ b/test/Julia_f_1.4.multiout
@@ -16,8 +16,10 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> 
 --------------------------------------------------
@@ -30,8 +32,10 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -44,14 +48,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::var"##3#6"{var"##4#7",Array{Int64,1}})(::TerminalRegressionTests.Emulated
-|Terminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::var"##25#29"{var"##26#30",Array{Int64,1}})(::TerminalRegressionTests.Emul
+|atedTerminal) at runtests.jl:30
 |
 |debug> 
 --------------------------------------------------
@@ -64,14 +70,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -84,14 +92,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::var"##3#6"{var"##4#7",Array{Int64,1}})(::TerminalRegressionTests.Emulated
-|Terminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::var"##25#29"{var"##26#30",Array{Int64,1}})(::TerminalRegressionTests.Emul
+|atedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- y::Array{Int64,1} = [1, 2, 3]
@@ -108,14 +118,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -132,14 +144,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::var"##3#6"{var"##4#7",Array{Int64,1}})(::TerminalRegressionTests.Emulated
-|Terminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::var"##25#29"{var"##26#30",Array{Int64,1}})(::TerminalRegressionTests.Emul
+|atedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- y::Array{Int64,1} = [1, 2, 3]
@@ -162,14 +176,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -192,14 +208,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::var"##3#6"{var"##4#7",Array{Int64,1}})(::TerminalRegressionTests.Emulated
-|Terminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::var"##25#29"{var"##26#30",Array{Int64,1}})(::TerminalRegressionTests.Emul
+|atedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- y::Array{Int64,1} = [1, 2, 3]
@@ -225,14 +243,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -258,14 +278,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] f(::Int64) at runtests.jl:7
-|[2] #4 at runtests.jl:37 [inlined]
-|[3] (::var"##3#6"{var"##4#7",Array{Int64,1}})(::TerminalRegressionTests.Emulated
-|Terminal) at runtests.jl:30
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::var"##25#29"{var"##26#30",Array{Int64,1}})(::TerminalRegressionTests.Emul
+|atedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- y::Array{Int64,1} = [1, 2, 3]
@@ -294,14 +316,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -318,5 +342,85 @@
 |
 |BBBBBBBCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Hit `@infiltrate` in f(::Int64) at runtests.jl:7:
+|
+|debug> ?
+|  Code entered is evaluated in the current function's module. Note that you cann
+|ot change local
+|  variables.
+|  The following commands are special cased:
+|    - `@trace`: Print the current stack trace.
+|    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
+|
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
+|
+|debug> @trace
+|[1] f(::Int64) at runtests.jl:7
+|[2] #26 at runtests.jl:37 [inlined]
+|[3] (::var"##25#29"{var"##26#30",Array{Int64,1}})(::TerminalRegressionTests.Emul
+|atedTerminal) at runtests.jl:30
+|
+|debug> @locals
+|- y::Array{Int64,1} = [1, 2, 3]
+|- x::Int64 = 2
+|
+|debug> x.*y
+|3-element Array{Int64,1}:
+| 2
+| 4
+| 6
+|
+|debug> foo
+|3
+|
+|debug> 0//0
+|ERROR: ArgumentError: invalid rational: zero(Int64)//zero(Int64)
+|
+|debug> @stop
+|
+|debug> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCC
+|CCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCC
+|
+|BBBBBBBCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCC
+|CC
+|CC
+|CC
+|
+|BBBBBBBCCC
+|C
+|
+|BBBBBBBCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCC
 |
 |BBBBBBB

--- a/test/Julia_g_1.1.multiout
+++ b/test/Julia_g_1.1.multiout
@@ -16,8 +16,10 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> 
 --------------------------------------------------
@@ -30,8 +32,10 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -44,14 +48,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] g at runtests.jl:13 [inlined]
-|[2] #5 at runtests.jl:43 [inlined]
-|[3] (::getfield(Main, Symbol("##3#6")){getfield(Main, Symbol("##5#8")),Int64})(:
-|:TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
+|[2] #28 at runtests.jl:51 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##28#32")),Int64
+|})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> 
 --------------------------------------------------
@@ -64,14 +70,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -84,14 +92,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] g at runtests.jl:13 [inlined]
-|[2] #5 at runtests.jl:43 [inlined]
-|[3] (::getfield(Main, Symbol("##3#6")){getfield(Main, Symbol("##5#8")),Int64})(:
-|:TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
+|[2] #28 at runtests.jl:51 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##28#32")),Int64
+|})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- x::Int64 = 24
@@ -107,14 +117,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCC
@@ -130,14 +142,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] g at runtests.jl:13 [inlined]
-|[2] #5 at runtests.jl:43 [inlined]
-|[3] (::getfield(Main, Symbol("##3#6")){getfield(Main, Symbol("##5#8")),Int64})(:
-|:TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
+|[2] #28 at runtests.jl:51 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##28#32")),Int64
+|})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- x::Int64 = 24
@@ -156,14 +170,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCC

--- a/test/Julia_g_1.2.multiout
+++ b/test/Julia_g_1.2.multiout
@@ -16,8 +16,10 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> 
 --------------------------------------------------
@@ -30,8 +32,10 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -44,14 +48,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] g at runtests.jl:13 [inlined]
-|[2] #5 at runtests.jl:43 [inlined]
-|[3] (::getfield(Main, Symbol("##3#6")){getfield(Main, Symbol("##5#8")),Int64})(:
-|:TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
+|[2] #28 at runtests.jl:51 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##28#32")),Int64
+|})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> 
 --------------------------------------------------
@@ -64,14 +70,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -84,14 +92,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] g at runtests.jl:13 [inlined]
-|[2] #5 at runtests.jl:43 [inlined]
-|[3] (::getfield(Main, Symbol("##3#6")){getfield(Main, Symbol("##5#8")),Int64})(:
-|:TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
+|[2] #28 at runtests.jl:51 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##28#32")),Int64
+|})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- x::Int64 = 24
@@ -107,14 +117,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCC
@@ -130,14 +142,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] g at runtests.jl:13 [inlined]
-|[2] #5 at runtests.jl:43 [inlined]
-|[3] (::getfield(Main, Symbol("##3#6")){getfield(Main, Symbol("##5#8")),Int64})(:
-|:TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
+|[2] #28 at runtests.jl:51 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##28#32")),Int64
+|})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- x::Int64 = 24
@@ -156,14 +170,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCC

--- a/test/Julia_g_1.3.multiout
+++ b/test/Julia_g_1.3.multiout
@@ -16,8 +16,10 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> 
 --------------------------------------------------
@@ -30,8 +32,10 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -44,14 +48,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] g at runtests.jl:13 [inlined]
-|[2] #5 at runtests.jl:43 [inlined]
-|[3] (::var"##3#6"{var"##5#8",Int64})(::TerminalRegressionTests.EmulatedTerminal)
-| at runtests.jl:30
+|[2] #28 at runtests.jl:51 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##28#32")),Int64
+|})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> 
 --------------------------------------------------
@@ -64,14 +70,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -84,14 +92,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] g at runtests.jl:13 [inlined]
-|[2] #5 at runtests.jl:43 [inlined]
-|[3] (::var"##3#6"{var"##5#8",Int64})(::TerminalRegressionTests.EmulatedTerminal)
-| at runtests.jl:30
+|[2] #28 at runtests.jl:51 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##28#32")),Int64
+|})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- x::Int64 = 24
@@ -107,14 +117,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCC
@@ -130,14 +142,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] g at runtests.jl:13 [inlined]
-|[2] #5 at runtests.jl:43 [inlined]
-|[3] (::var"##3#6"{var"##5#8",Int64})(::TerminalRegressionTests.EmulatedTerminal)
-| at runtests.jl:30
+|[2] #28 at runtests.jl:51 [inlined]
+|[3] (::getfield(Main, Symbol("##25#29")){getfield(Main, Symbol("##28#32")),Int64
+|})(::TerminalRegressionTests.EmulatedTerminal) at runtests.jl:30
 |
 |debug> @locals
 |- x::Int64 = 24
@@ -156,14 +170,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCC

--- a/test/Julia_g_1.4.multiout
+++ b/test/Julia_g_1.4.multiout
@@ -16,8 +16,10 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> 
 --------------------------------------------------
@@ -30,8 +32,10 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -44,14 +48,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] g at runtests.jl:13 [inlined]
-|[2] #5 at runtests.jl:43 [inlined]
-|[3] (::var"##3#6"{var"##5#8",Int64})(::TerminalRegressionTests.EmulatedTerminal)
-| at runtests.jl:30
+|[2] #28 at runtests.jl:51 [inlined]
+|[3] (::var"##25#29"{var"##28#32",Int64})(::TerminalRegressionTests.EmulatedTermi
+|nal) at runtests.jl:30
 |
 |debug> 
 --------------------------------------------------
@@ -64,14 +70,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -84,14 +92,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] g at runtests.jl:13 [inlined]
-|[2] #5 at runtests.jl:43 [inlined]
-|[3] (::var"##3#6"{var"##5#8",Int64})(::TerminalRegressionTests.EmulatedTerminal)
-| at runtests.jl:30
+|[2] #28 at runtests.jl:51 [inlined]
+|[3] (::var"##25#29"{var"##28#32",Int64})(::TerminalRegressionTests.EmulatedTermi
+|nal) at runtests.jl:30
 |
 |debug> @locals
 |- x::Int64 = 24
@@ -107,14 +117,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCC
@@ -130,14 +142,16 @@
 |  The following commands are special cased:
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
+|    - `@stop`: Stop infiltrating at this `@infiltrate` spot.
 |
-|  Exit this REPL mode with `Ctrl-D`.
+|  Exit this REPL mode with `Ctrl-D`, and clear the effect of `@stop` with `Infil
+|trator.clear_stop()`.
 |
 |debug> @trace
 |[1] g at runtests.jl:13 [inlined]
-|[2] #5 at runtests.jl:43 [inlined]
-|[3] (::var"##3#6"{var"##5#8",Int64})(::TerminalRegressionTests.EmulatedTerminal)
-| at runtests.jl:30
+|[2] #28 at runtests.jl:51 [inlined]
+|[3] (::var"##25#29"{var"##28#32",Int64})(::TerminalRegressionTests.EmulatedTermi
+|nal) at runtests.jl:30
 |
 |debug> @locals
 |- x::Int64 = 24
@@ -156,14 +170,16 @@
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCC
 |CCCCCCCCCCCCCCC

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,8 +18,8 @@ if Sys.isunix() && VERSION >= v"1.1.0"
     using TerminalRegressionTests
 
     function run_terminal_test(func, result, commands, validation)
-        TerminalRegressionTests.automated_test(joinpath(@__DIR__, validation), commands) do emuterm
-        # TerminalRegressionTests.create_automated_test(joinpath(@__DIR__, validation), commands) do emuterm
+        # TerminalRegressionTests.automated_test(joinpath(@__DIR__, validation), commands) do emuterm
+        TerminalRegressionTests.create_automated_test(joinpath(@__DIR__, validation), commands) do emuterm
             repl = REPL.LineEditREPL(emuterm, true)
             repl.interface = REPL.setup_interface(repl)
             repl.specialdisplay = REPL.REPLDisplay(repl)
@@ -35,8 +35,16 @@ if Sys.isunix() && VERSION >= v"1.1.0"
     end
 
     run_terminal_test(() -> f(3), [3, 4, 5],
-                      ["?\n", "@trace\n", "@locals\n", "x.*y\n", "foo\n", "0//0\n", "\x4"],
+                      ["?\n", "@trace\n", "@locals\n", "x.*y\n", "foo\n", "0//0\n", "@stop\n", "\x4"],
                       "Julia_f_$(VERSION.major).$(VERSION.minor).multiout")
+
+    @test f(3) == [3, 4, 5] # `@stop`ped `@infiltrate` should not open a prompt
+
+    Infiltrator.clear_stop()
+
+    run_terminal_test(() -> f(3), [3, 4, 5],
+                      ["@locals\n", "\x4"],
+                      "Julia_f2_$(VERSION.major).$(VERSION.minor).multiout")
 
     @test g(1) == 12 # conditional @infiltrate should not open a prompt
 


### PR DESCRIPTION
Thanks for this great package!
Here is an attempt at solving a small problem: when `@infiltrate` is in a loop which is reapeated so many times that you don't want to inspect each time it's hit, there is currently no escape, besides keeping `Ctrl-D` pressed, at the risk of quitting your julia session and your shell.

This adds a `@stop` command to stop infiltrating at the current spot, by maintaining a `STOP_SPOTS` set containing locations of such spots (caveat: two `@inflitrate` on the same line won't work well).
It doesn't seem ideal to have a global variable like that, but this is the only approach I could come up with!
This needs tests, but I have no idea how to do that...