### PR TITLE
improve scratch pad story

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,23 @@ Assigns all local variables into the scratch pad.
 Originally implemented and named by Antoine Levitt in [Exfiltrator.jl](https://github.com/antoine-levitt/Exfiltrator.jl).
 
 ## The scratch pad
-The scratch pad is an anonymous module into which you can assign variables/functions while
-`@infiltrate`ing or via `@exfiltrate`. You can get a reference to it via `get_scratch_pad`
-and reset it with `clear_scratch_pad`.
+Exfiltrating variables (with `@exfiltrate` or by assignment in a `@infiltrate` session) happens by
+assigning the variable to a global scratch pad (backed by a module). You can access this store with
+`Infiltrator.store`; any exfiltrated objects can be directly accessed, e.g. via `Infilatrator.store.mysymbol`.
+
+You can reset the module with `Infiltrator.clear_store` or assign a specific module with `Infiltrator.set_store`.
+This allows you to e.g. set the backing module to `Main` (although I wouldn't recommend doing so):
+```
+julia> foo(x) = @exfiltrate
+foo (generic function with 1 method)
+
+julia> Infiltrator.set_store(Main)
+
+julia> foo(3)
+
+julia> x
+3
+```
 
 ## Example usage:
 ```julia
@@ -109,7 +123,7 @@ infil> @exit
  4
  6
 
-julia> get_scratch_pad().intermediate
+julia> Infiltrator.store.intermediate
 1-element Vector{Any}:
  2
 ```

--- a/README.md
+++ b/README.md
@@ -26,22 +26,20 @@ when its condition is `true`.
 ## `@exfiltrate`
     @exfiltrate
 
-Assigns all local variables into the scratch pad.
+Assigns all local variables into the global store.
 
-Originally implemented and named by Antoine Levitt in [Exfiltrator.jl](https://github.com/antoine-levitt/Exfiltrator.jl).
-
-## The scratch pad
+## The global store
 Exfiltrating variables (with `@exfiltrate` or by assignment in a `@infiltrate` session) happens by
-assigning the variable to a global scratch pad (backed by a module). You can access this store with
-`Infiltrator.store`; any exfiltrated objects can be directly accessed, e.g. via `Infilatrator.store.mysymbol`.
+assigning the variable to a global store (backed by a module). You can access this store with
+`Infiltrator.store`; any exfiltrated objects can be directly accessed, e.g. via `Infilatrator.store.myvar`.
 
-You can reset the module with `Infiltrator.clear_store` or assign a specific module with `Infiltrator.set_store`.
+You can reset the module with `Infiltrator.clear_store!()` or assign a specific module with `Infiltrator.set_store!(mod)`.
 This allows you to e.g. set the backing module to `Main` (although I wouldn't recommend doing so):
 ```
 julia> foo(x) = @exfiltrate
 foo (generic function with 1 method)
 
-julia> Infiltrator.set_store(Main)
+julia> Infiltrator.set_store!(Main)
 
 julia> foo(3)
 
@@ -66,17 +64,17 @@ Infiltrating f(x::Vector{Int64}) at REPL[7]:5:
 
 infil> ?
   Code entered is evaluated in the current functions module. Note that you cannot change local
-  variables, but can assign to globals in a permanent scratch pad module.
+  variables, but can assign to globals in a permanent store module.
 
   The following commands are special cased:
     - `?`: Print this help text.
     - `@trace`: Print the current stack trace.
     - `@locals`: Print local variables.
-    - `@exfiltrate`: Save all local variables into the scratch pad.
-    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with `Infiltrator.clear_disabled()`).
+    - `@exfiltrate`: Save all local variables into the store.
+    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with `Infiltrator.clear_disabled!()`).
     - `@continue`: Continue to the next infiltration point or exit (shortcut: Ctrl-D).
     - `@exit`: Stop infiltrating for the remainder of this session and exit (on Julia versions prior to
-      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 
 infil> @locals
 - out::Vector{Any} = Any[2]

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ when its condition is `true`.
 ## `@exfiltrate`
     @exfiltrate
 
-Assigns all local variables into the global store.
+Assigns all local variables into the global storage.
 
-## The global store
+## The safehouse
 Exfiltrating variables (with `@exfiltrate` or by assignment in a `@infiltrate` session) happens by
-assigning the variable to a global store (backed by a module). You can access this store with
-`Infiltrator.store`; any exfiltrated objects can be directly accessed, e.g. via `Infilatrator.store.myvar`.
+assigning the variable to a global storage space (backed by a module); any exfiltrated objects
+can be directly accessed, either via the exported `safehouse` or `Infilatrator.store`.
 
 You can reset the module with `Infiltrator.clear_store!()` or assign a specific module with `Infiltrator.set_store!(mod)`.
 This allows you to e.g. set the backing module to `Main` (although I wouldn't recommend doing so):
@@ -95,7 +95,7 @@ Stacktrace:
  [5] top-level scope
    @ none:1
 
-infil> intermediate = copy(out)
+infil> intermediate = copy(out) # assigned (or `@exfiltrate`d) variables can be accessed from the safehouse
 1-element Vector{Any}:
  2
 
@@ -121,7 +121,7 @@ infil> @exit
  4
  6
 
-julia> Infiltrator.store.intermediate
+julia> safehouse.intermediate
 1-element Vector{Any}:
  2
 ```

--- a/src/Infiltrator.jl
+++ b/src/Infiltrator.jl
@@ -8,7 +8,7 @@ export @infiltrate, @exfiltrate
 
 REPL_HOOKED = Ref{Bool}(false)
 function __init__()
-  store.store = Module()
+  clear_store!(store)
   if VERSION >= v"1.5.0-DEV.282"
     if isdefined(Base, :active_repl_backend)
         pushfirst!(Base.active_repl_backend.ast_transforms, exit_transform)
@@ -57,15 +57,15 @@ end
 """
     @exfiltrate
 
-Assigns all local variables into the scratch pad.
+Assigns all local variables into the store.
 """
 macro exfiltrate()
   quote
     for (k, v) in Base.@locals
       try
-        Core.eval($(store).store, Expr(:(=), k, QuoteNode(v)))
+        Core.eval(getfield($(store), :store), Expr(:(=), k, QuoteNode(v)))
       catch err
-        println(stderr, "Assignment to scratchpad variable failed.")
+        println(stderr, "Assignment to store variable failed.")
         Base.display_error(stderr, err, catch_backtrace())
       end
     end
@@ -82,48 +82,45 @@ const TEST_TERMINAL_REF = Ref{Any}(nothing)
 const TEST_REPL_REF = Ref{Any}(nothing)
 const TEST_NOSTACK = Ref{Any}(false)
 
-mutable struct ScratchPad
+mutable struct Store
   store::Module
   exiting::Bool
   disabled::Set
 end
-function Base.show(io::IO, s::ScratchPad)
+function Base.show(io::IO, s::Store)
   n = length(get_scratch_pad_names(s))
-  print(io, "Infiltrator scratch pad with $(n) name$(n == 1 ? "" : "s")")
+  print(io, "Infiltrator store with $(n) name$(n == 1 ? "" : "s")")
 end
-function Base.getproperty(sp::ScratchPad, s::Symbol)
-  s === :store && return getfield(sp, :store)
-  s === :exiting && return getfield(sp, :exiting)
-  s === :disabled && return getfield(sp, :disabled)
-
-  if isdefined(sp.store, s)
-    getproperty(sp.store, s)
+function Base.getproperty(sp::Store, s::Symbol)
+  m = getfield(sp, :store)
+  if isdefined(m, s)
+    getproperty(m, s)
   else
     throw(UndefVarError(s))
   end
 end
-Base.propertynames(s::ScratchPad) = keys(get_scratch_pad_names(s))
+Base.propertynames(s::Store) = keys(get_scratch_pad_names(s))
 
 """
     store
 
-Global scratch pad for storing values while `@infiltrate`ing or `@exfiltrate`ing.
+Global store for storing values while `@infiltrate`ing or `@exfiltrate`ing.
 """
-const store = ScratchPad(Module(), false, Set())
+const store = Store(Module(), false, Set())
 
 """
-    @with ex
+    @withstore ex
 
-Evaluates the expression `ex` in the context of the global scratch pad.
+Evaluates the expression `ex` in the context of the global store.
 
-Mainly intended for interactive use, as changes to the scratch pads state will not
+Mainly intended for interactive use, as changes to the stores state will not
 propagate into the returned expression.
 """
-macro with(ex)
-  with_scratch_pad(ex)
+macro withstore(ex)
+  withstore(ex)
 end
 
-function with_scratch_pad(ex)
+function withstore(ex)
   ns = get_scratch_pad_names(store)
   return Expr(:let,
     Expr(:block, map(x->Expr(:(=), x...), [(k, maybe_quote(v)) for (k, v) in ns])...),
@@ -132,42 +129,42 @@ function with_scratch_pad(ex)
 end
 
 """
-    clear_disabled(s = store)
+    clear_disabled!(s = store)
 
 Clear all disabled infiltration points.
 """
-function clear_disabled(s = store)
-  empty!(s.disabled)
+function clear_disabled!(s = store)
+  empty!(getfield(s, :disabled))
   return nothing
 end
 
 """
-    end_session(s = store)
+    end_session!(s = store)
 
 End this infiltration session (reverts the effect of `@exit` in the `debug>` REPL).
 
 Only needs to be manually called on Julia versions prior to 1.5.
 """
-function end_session(s::ScratchPad = store)
-  s.exiting = false
+function end_session!(s::Store = store)
+  setfield!(s, :exiting, false)
   return nothing
 end
 
 """
-    clear_store(s::ScratchPad = Infiltrator.store)
+    clear_store!(s::Store = Infiltrator.store)
 
-Reset the scratch pad used for global symbols.
+Reset the store used for global symbols.
 """
-clear_store(s::ScratchPad = store) = set_store(s, Module())
+clear_store!(s::Store = store) = set_store!(s, Module())
 
 """
-    set_store(s::ScratchPad = Infiltrator.store, m::Module)
+    set_store!(s::Store = Infiltrator.store, m::Module)
 
-Set the module backing the scratch pad `s`.
+Set the module backing the store `s`.
 """
-set_store(m::Module) = set_store(store, m)
-function set_store(s::ScratchPad, m::Module)
-  s.store = m
+set_store!(m::Module) = set_store!(store, m)
+function set_store!(s::Store, m::Module)
+  setfield!(s, :store, m)
   nothing
 end
 
@@ -176,8 +173,8 @@ function start_prompt(mod, locals, file, fileline;
                         repl = TEST_REPL_REF[],
                         nostack = TEST_NOSTACK[]
                       )
-  store.exiting && return
-  (file, fileline) in store.disabled && return
+  getfield(store, :exiting) && return
+  (file, fileline) in getfield(store, :disabled) && return
 
   if terminal === nothing || repl === nothing
     if isdefined(Base, :active_repl) && isdefined(Base.active_repl, :t)
@@ -206,17 +203,17 @@ end
 function show_help(io)
   println(io, """
     Code entered is evaluated in the current functions module. Note that you cannot change local
-    variables, but can assign to globals in a permanent scratch pad module.
+    variables, but can assign to globals in a permanent store module.
 
     The following commands are special cased:
       - `?`: Print this help text.
       - `@trace`: Print the current stack trace.
       - `@locals`: Print local variables.
-      - `@exfiltrate`: Save all local variables into the scratch pad.
-      - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with `Infiltrator.clear_disabled()`).
+      - `@exfiltrate`: Save all local variables into the store.
+      - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with `Infiltrator.clear_disabled!()`).
       - `@continue`: Continue to the next infiltration point or exit (shortcut: Ctrl-D).
       - `@exit`: Stop infiltrating for the remainder of this session and exit (on Julia versions prior to
-        1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+        1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
   """)
 end
 
@@ -301,13 +298,13 @@ function debugprompt(mod, locals, trace, terminal, repl, nostack = false; file, 
         return true
       elseif sline == "@exfiltrate"
         n = length(locals)
-        println(io, "Exfiltrating $(n) local variable$(n == 1 ? "" : "s") into the scratch pad.\n")
+        println(io, "Exfiltrating $(n) local variable$(n == 1 ? "" : "s") into the store.\n")
 
         for (k, v) in locals
           try
-            Core.eval(store.store, Expr(:(=), k, QuoteNode(v)))
+            Core.eval(getfield(store, :store), Expr(:(=), k, QuoteNode(v)))
           catch err
-            println(io, "Assignment to scratchpad variable failed.")
+            println(io, "Assignment to store variable failed.")
             Base.display_error(io, err, catch_backtrace())
           end
         end
@@ -315,17 +312,18 @@ function debugprompt(mod, locals, trace, terminal, repl, nostack = false; file, 
         return true
       elseif sline == "@toggle"
         spot = (file, fileline)
-        if spot in store.disabled
-          delete!(store.disabled, spot)
+        ds = getfield(store, :disabled)
+        if spot in ds
+          delete!(ds, spot)
           println(io, "Enabled infiltration at this infiltration point.\n")
         else
-          push!(store.disabled, spot)
+          push!(ds, spot)
           println(io, "Disabled infiltration at this infiltration point.\n")
         end
         LineEdit.reset_state(s)
         return true
       elseif sline == "@exit"
-        store.exiting = true
+        setfield!(store, :exiting, true)
         if !REPL_HOOKED[]
           println(io, "Revert the effect of this with `Infiltrator.end_session()` or you will not be able to enter a new session!")
         end
@@ -392,11 +390,12 @@ function debugprompt(mod, locals, trace, terminal, repl, nostack = false; file, 
 end
 
 function get_scratch_pad_names(s = store)
-  ns = names(s.store, all = true)
+  m = getfield(s, :store)
+  ns = names(m, all = true)
   out = Dict()
   for n in ns
-    if isdefined(s.store, n) && n !== :eval && n !== :include && n !== :anonymous
-      out[n] = getfield(s.store, n)
+    if isdefined(m, n) && n !== :eval && n !== :include && n !== :anonymous
+      out[n] = getfield(m, n)
     end
   end
   out
@@ -437,9 +436,9 @@ function interpret(io, expr, mod, locals)
       end
     else
       try
-        Core.eval(store.store, Expr(:(=), assignment, QuoteNode(eval_res)))
+        Core.eval(getfield(store, :store), Expr(:(=), assignment, QuoteNode(eval_res)))
       catch err
-        println(io, "Assignment to scratchpad variable failed.")
+        println(io, "Assignment to store variable failed.")
         Base.display_error(io, err, catch_backtrace())
       end
     end

--- a/test/Julia_f_1.1.multiout
+++ b/test/Julia_f_1.1.multiout
@@ -12,20 +12,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> 
 --------------------------------------------------
@@ -34,20 +34,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -56,20 +56,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] f(::Int64) at runtests.jl:7
@@ -84,20 +84,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -112,20 +112,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] f(::Int64) at runtests.jl:7
@@ -144,20 +144,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -176,20 +176,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] f(::Int64) at runtests.jl:7
@@ -214,20 +214,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -252,20 +252,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] f(::Int64) at runtests.jl:7
@@ -295,20 +295,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -338,20 +338,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] f(::Int64) at runtests.jl:7
@@ -384,20 +384,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -430,20 +430,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] f(::Int64) at runtests.jl:7
@@ -479,20 +479,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -528,20 +528,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] f(::Int64) at runtests.jl:7
@@ -580,20 +580,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -632,20 +632,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] f(::Int64) at runtests.jl:7
@@ -687,20 +687,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -742,20 +742,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] f(::Int64) at runtests.jl:7
@@ -800,20 +800,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC

--- a/test/Julia_f_1.6.multiout
+++ b/test/Julia_f_1.6.multiout
@@ -12,20 +12,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> 
 --------------------------------------------------
@@ -34,20 +34,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -56,20 +56,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] f(x::Int64) at runtests.jl:7
@@ -84,20 +84,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -112,20 +112,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] f(x::Int64) at runtests.jl:7
@@ -144,20 +144,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -176,20 +176,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] f(x::Int64) at runtests.jl:7
@@ -214,20 +214,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -252,20 +252,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] f(x::Int64) at runtests.jl:7
@@ -295,20 +295,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -338,20 +338,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] f(x::Int64) at runtests.jl:7
@@ -384,20 +384,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -430,20 +430,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] f(x::Int64) at runtests.jl:7
@@ -479,20 +479,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -528,20 +528,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] f(x::Int64) at runtests.jl:7
@@ -580,20 +580,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -632,20 +632,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] f(x::Int64) at runtests.jl:7
@@ -687,20 +687,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -742,20 +742,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] f(x::Int64) at runtests.jl:7
@@ -800,20 +800,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC

--- a/test/Julia_g_1.1.multiout
+++ b/test/Julia_g_1.1.multiout
@@ -12,20 +12,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> 
 --------------------------------------------------
@@ -34,20 +34,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -56,20 +56,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] g at runtests.jl:13 [inlined]
@@ -84,20 +84,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -112,20 +112,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] g at runtests.jl:13 [inlined]
@@ -143,20 +143,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -174,20 +174,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] g at runtests.jl:13 [inlined]
@@ -208,20 +208,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC

--- a/test/Julia_g_1.6.multiout
+++ b/test/Julia_g_1.6.multiout
@@ -12,20 +12,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> 
 --------------------------------------------------
@@ -34,20 +34,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -56,20 +56,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] g at runtests.jl:13 [inlined]
@@ -84,20 +84,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -112,20 +112,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] g at runtests.jl:13 [inlined]
@@ -143,20 +143,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -174,20 +174,20 @@
 |infil> ?
 |  Code entered is evaluated in the current functions module. Note that you canno
 |t change local
-|  variables, but can assign to globals in a permanent scratch pad module.
+|  variables, but can assign to globals in a permanent store module.
 |
 |  The following commands are special cased:
 |    - `?`: Print this help text.
 |    - `@trace`: Print the current stack trace.
 |    - `@locals`: Print local variables.
-|    - `@exfiltrate`: Save all local variables into the scratch pad.
+|    - `@exfiltrate`: Save all local variables into the store.
 |    - `@toggle`: Toggle infiltrating at this `@infiltrate` spot (clear all with 
-|`Infiltrator.clear_disabled()`).
+|`Infiltrator.clear_disabled!()`).
 |    - `@continue`: Continue to the next infiltration point or exit (shortcut: Ct
 |rl-D).
 |    - `@exit`: Stop infiltrating for the remainder of this session and exit (on 
 |Julia versions prior to
-|      1.5 this needs to be manually cleared with `Infiltrator.end_session()`).
+|      1.5 this needs to be manually cleared with `Infiltrator.end_session!()`).
 |
 |infil> @trace
 |[1] g at runtests.jl:13 [inlined]
@@ -208,20 +208,20 @@
 |BBBBBBBC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCC
 |CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC

--- a/test/Julia_scoping_1.1.multiout
+++ b/test/Julia_scoping_1.1.multiout
@@ -30,7 +30,7 @@
 |- xxxxx::Int64 = 4
 |
 |infil> @exfiltrate
-|Exfiltrating 2 local variables into the scratch pad.
+|Exfiltrating 2 local variables into the store.
 |
 |infil> 
 --------------------------------------------------
@@ -41,6 +41,6 @@
 |CCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB

--- a/test/Julia_scoping_1.6.multiout
+++ b/test/Julia_scoping_1.6.multiout
@@ -30,7 +30,7 @@
 |- xxxxx::Int64 = 4
 |
 |infil> @exfiltrate
-|Exfiltrating 2 local variables into the scratch pad.
+|Exfiltrating 2 local variables into the store.
 |
 |infil> 
 --------------------------------------------------
@@ -41,6 +41,6 @@
 |CCCCCCCCCCCCCCCCCC
 |
 |BBBBBBBCCCCCCCCCCC
-|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 |
 |BBBBBBB

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,19 +82,17 @@ end
                         ["@locals\n", "xxxxx = 12\n", "foo(x) = x\n", "function bar(x); 2x; end\n", "x = 2\n", "\x4"],
                         "Julia_exfil_$(VERSION.major).$(VERSION.minor).multiout")
 
-        m = get_scratch_pad()
-        @test m.xxxxx == 12
-        @test m.foo(3) == 3
-        @test m.bar(3) == 6
-        @test !isdefined(m, :x)
+        @test Infiltrator.store.xxxxx == 12
+        @test Infiltrator.store.foo(3) == 3
+        @test Infiltrator.store.bar(3) == 6
+        @test !isdefined(Infiltrator.store.store, :x)
 
         # proper scoping of scratch pad
         run_terminal_test(() -> j(2), 8,
                         ["@locals\n", "@exfiltrate\n", "\x4"],
                         "Julia_scoping_$(VERSION.major).$(VERSION.minor).multiout")
 
-        m = get_scratch_pad()
-        @test m.xxxxx == 4
+        @test Infiltrator.store.xxxxx == 4
 
         # persistent history
         run_terminal_test(() -> h([1,2,3]), [[3,4,5], [3,4,5], [3,4,5]],
@@ -106,7 +104,7 @@ end
 end
 
 @testset "exfiltration tests" begin
-    Infiltrator.clear_scratch_pad()
+    Infiltrator.clear_store()
     function foo_ex(x)
         y = 3
         foo = :asd
@@ -115,8 +113,12 @@ end
     end
     foo_ex(55)
 
-    m = get_scratch_pad()
-    @test m.y == 3
-    @test m.foo == :asd
-    @test m.bar(3) == 3
+    @test Infiltrator.store.y == 3
+    @test Infiltrator.store.foo == :asd
+    @test Infiltrator.store.bar(3) == 3
+    @test_throws UndefVarError Infiltrator.store.asd
+
+    # `@with` is basically for dynamic usage only
+    @test 6 == Core.eval(@__MODULE__, :(Infiltrator.@with(2y)))
+    @test "asd" == Core.eval(@__MODULE__, :(Infiltrator.@with(string(foo))))
 end


### PR DESCRIPTION
This improves the scratch pad/storage story a bit by
- adding a `@with` macro for interactive use,
- changing to a `Infiltrator.store` global to access the store (with proper autocompletion),
- and exposing `set_store(Main)` for the Exfiltrate behavior.

cc @antoine-levitt, @pdeffebach