### PR TITLE
escape `GlobalRef`

### DIFF
--- a/src/Infiltrator.jl
+++ b/src/Infiltrator.jl
@@ -816,6 +816,7 @@ function maybe_quote(@nospecialize x)
   is_ir_construct(x) && return QuoteNode(x)
   isa(x, Expr) && return QuoteNode(x)
   isa(x, Symbol) && return QuoteNode(x)
+  isa(x, GlobalRef) && return QuoteNode(x)
   return x
 end
 

--- a/test/outputs/Julia_globalref_1.1.multiout
+++ b/test/outputs/Julia_globalref_1.1.multiout
@@ -1,0 +1,22 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> gr
+|:(Main.undefvar)
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCC
+|CCCCCCCCCCCCCCCC
+|
+|BBBBBBB

--- a/test/outputs/Julia_globalref_1.10.multiout
+++ b/test/outputs/Julia_globalref_1.10.multiout
@@ -1,0 +1,22 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> gr
+|:(Main.undefvar)
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCC
+|CCCCCCCCCCCCCCCC
+|
+|BBBBBBB

--- a/test/outputs/Julia_globalref_1.6.multiout
+++ b/test/outputs/Julia_globalref_1.6.multiout
@@ -1,0 +1,22 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> gr
+|:(Main.undefvar)
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCC
+|CCCCCCCCCCCCCCCC
+|
+|BBBBBBB

--- a/test/outputs/Julia_globalref_1.7.multiout
+++ b/test/outputs/Julia_globalref_1.7.multiout
@@ -1,0 +1,22 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> gr
+|:(Main.undefvar)
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCC
+|CCCCCCCCCCCCCCCC
+|
+|BBBBBBB

--- a/test/outputs/Julia_globalref_1.8.multiout
+++ b/test/outputs/Julia_globalref_1.8.multiout
@@ -1,0 +1,22 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> gr
+|:(Main.undefvar)
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCC
+|CCCCCCCCCCCCCCCC
+|
+|BBBBBBB

--- a/test/outputs/Julia_globalref_1.9.multiout
+++ b/test/outputs/Julia_globalref_1.9.multiout
@@ -1,0 +1,22 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> gr
+|:(Main.undefvar)
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCC
+|CCCCCCCCCCCCCCCC
+|
+|BBBBBBB

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,6 +78,12 @@ function infiltry(x)
     @infiltry x//x
 end
 
+function globalref(m, s)
+    gr = GlobalRef(m, s)
+    @infiltrate
+    return gr
+end
+
 @testset "infiltration tests" begin
     if Sys.isunix() && VERSION >= v"1.1.0"
         using TerminalRegressionTests
@@ -186,6 +192,10 @@ end
         run_terminal_test((t) -> Jmod.jfunc(), nothing,
                           ["x\n", "randstring\n", "@exit\n"],
                           "Julia_imported_globals_$(VERSION.major).$(VERSION.minor).multiout")
+
+        run_terminal_test((t) -> globalref(Main, :undefvar), GlobalRef(Main, :undefvar),
+                           ["gr\n", "@exit\n"],
+                           "Julia_globalref_$(VERSION.major).$(VERSION.minor).multiout")
 
         # safehouse should not shadow local variables
         run_terminal_test((t) -> multiexfiltrate(), nothing,


### PR DESCRIPTION
`GlobalRef` is a part of Julia IR, so it needs to be escaped. I'm not sure how to add new tests: I generated one `multiout` file for v1.10 and copied it to the other versions.