### PR TITLE
adapt to linetable changes in Julia nightly

### DIFF
--- a/src/Infiltrator.jl
+++ b/src/Infiltrator.jl
@@ -882,11 +882,15 @@ function find_first_topelevel_scope(bt::Vector{<:Union{Base.InterpreterIP,Ptr{Cv
       ind = findfirst(st) do frame
           linfo = frame.linfo
           if linfo isa Core.CodeInfo
-              linetable = linfo.linetable
-              if isa(linetable, Vector) && length(linetable) ≥ 1
-                  lin = first(linetable)
-                  if isa(lin, Core.LineInfoNode) && lin.method === StackTraces.top_level_scope_sym
-                      return true
+              @static if hasfield(Core.CodeInfo, :debuginfo)
+                  linfo.debuginfo.def === StackTraces.top_level_scope_sym && return true
+              else
+                  linetable = linfo.linetable
+                  if isa(linetable, Vector) && length(linetable) ≥ 1
+                      lin = first(linetable)
+                      if isa(lin, Core.LineInfoNode) && lin.method === StackTraces.top_level_scope_sym
+                          return true
+                      end
                   end
               end
           else


### PR DESCRIPTION
fixes #126

Note: Tests on 1.11 and 1.12 seem broken due to breakages in TerminalRegressionTests, but I was able to confirm that this fixed the error I encountered, i.e. this doesn't crash the infiltrate session anymore:

```julia-repl
julia> (() -> @infiltrate)()
Infiltrating (::var"#2#3")()
  at REPL[2]:1


infil> error()
ERROR: 
Stacktrace:
  [1] error()
    @ Base ./error.jl:53
  [2] top-level scope
    @ none:1
  [3] top-level scope
    @ none:1
  [4] eval
    @ ./boot.jl:439 [inlined]
  [5] interpret(expr::Expr, evalmod::Module)
    @ Infiltrator ~/.julia/dev/Infiltrator/src/Infiltrator.jl:864
  [6] (::Infiltrator.var"#26#27"{Bool, String, Int64, Dict{…}, Vector{…}, REPL.LineEditREPL, Nothing, Nothing, Module, Base.TTY})(s::REPL.LineEdit.MIState, buf::IOBuffer, ok::Bool)
    @ Infiltrator ~/.julia/dev/Infiltrator/src/Infiltrator.jl:688
  [7] #invokelatest#1
    @ ./essentials.jl:1048 [inlined]
  [8] invokelatest
    @ ./essentials.jl:1045 [inlined]
  [9] run_interface(terminal::REPL.Terminals.TextTerminal, m::REPL.LineEdit.ModalInterface, s::REPL.LineEdit.MIState)
    @ REPL.LineEdit ~/.julia/juliaup/julia-nightly/share/julia/stdlib/v1.12/REPL/src/LineEdit.jl:2766
 [10] run_interface
    @ ~/.julia/juliaup/julia-nightly/share/julia/stdlib/v1.12/REPL/src/LineEdit.jl:2760 [inlined]
 [11] debugprompt(mod::Module, locals::Dict{…}, trace::Vector{…}, terminal::REPL.Terminals.TTYTerminal, repl::REPL.LineEditREPL, ex::Nothing, bt::Nothing; nostack::Bool, file::String, fileline::Int64)
    @ Infiltrator ~/.julia/dev/Infiltrator/src/Infiltrator.jl:739
 [12] start_prompt(mod::Module, locals::Dict{Symbol, Any}, file::String, fileline::Int64, ex::Nothing, bt::Nothing; terminal::Nothing, repl::Nothing, nostack::Bool)
    @ Infiltrator ~/.julia/dev/Infiltrator/src/Infiltrator.jl:400
 [13] start_prompt(mod::Module, locals::Dict{Symbol, Any}, file::String, fileline::Int64, ex::Nothing, bt::Nothing)
    @ Infiltrator ~/.julia/dev/Infiltrator/src/Infiltrator.jl:300
 [14] start_prompt
    @ ~/.julia/dev/Infiltrator/src/Infiltrator.jl:300 [inlined]
 [15] macro expansion
    @ ~/.julia/dev/Infiltrator/src/Infiltrator.jl:68 [inlined]
 [16] (::var"#2#3")()
    @ Main ./REPL[2]:1
 [17] top-level scope
    @ REPL[2]:1
 [18] top-level scope
    @ REPL:1
Some type information was truncated. Use `show(err)` to see complete types.

infil> 
```