### PR TITLE
Add `global` qualifier to inserted globals

### DIFF
--- a/src/Infiltrator.jl
+++ b/src/Infiltrator.jl
@@ -530,7 +530,7 @@ function init_transient_eval_module(mod, locals)
   # insert variables in safehouse
   Core.eval(newmod, Expr(:block, map(x->Expr(:(=), x...), [(k, maybe_quote(v)) for (k, v) in get_store_names() if !isdefined(newmod, k)])...))
   # insert all bindings from the source module that aren't already defined in the eval module
-  Core.eval(newmod, Expr(:block, map(x->Expr(:(=), x...), [(k, maybe_quote(v)) for (k, v) in modns if !isdefined(newmod, k)])...))
+  Core.eval(newmod, Expr(:block, map(x->Expr(:global, Expr(:(=), x...)), [(k, maybe_quote(v)) for (k, v) in modns if !isdefined(newmod, k)])...))
 
   return newmod
 end


### PR DESCRIPTION
Disambiguates global assignments that used to be allowed but that no longer are after https://github.com/JuliaLang/julia/pull/57253.

It makes this error go away on nightly:
```julia
julia> using Infiltrator

julia> @infiltrate
Infiltrating top-level frame

ERROR: invalid assignment to constant anonymous.@__MODULE__. This redefinition may be permitted using the `const` keyword.
Stacktrace:
 [1] top-level scope
   @ none:1
 [2] eval(m::Module, e::Any)
   @ Core ./boot.jl:488
 [3] init_transient_eval_module(mod::Module, locals::Dict{Symbol, Any})
   @ Infiltrator ~/julia/wip3/.julia/dev/Infiltrator/src/Infiltrator.jl:533
```