### PR TITLE
Don't reevaluate `at__MODULE__`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Infiltrator"
 uuid = "5903a43b-9cc3-4c30-8d17-598619ec4e9b"
-version = "1.8.4"
+version = "1.8.5"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/Infiltrator.jl
+++ b/src/Infiltrator.jl
@@ -530,7 +530,7 @@ function init_transient_eval_module(mod, locals)
   # insert variables in safehouse
   Core.eval(newmod, Expr(:block, map(x->Expr(:(=), x...), [(k, maybe_quote(v)) for (k, v) in get_store_names() if !isdefined(newmod, k)])...))
   # insert all bindings from the source module that aren't already defined in the eval module
-  Core.eval(newmod, Expr(:block, map(x->Expr(:global, Expr(:(=), x...)), [(k, maybe_quote(v)) for (k, v) in modns if !isdefined(newmod, k)])...))
+  Core.eval(newmod, Expr(:block, map(x->Expr(:(=), x...), [(k, maybe_quote(v)) for (k, v) in modns if !isdefined(newmod, k) && k !== Symbol("@__MODULE__")])...))
 
   return newmod
 end


### PR DESCRIPTION
I realized that #131 does not actually fix the issue on nightly (and was tricked into believing it did by a faulty setup :facepalm:). The issue is caused by this behavior:

```julia
julia> let; global mod = Module()
           println(isdefined(mod, Symbol("@xx")))
           Core.eval(mod, :(macro xx() end))
           println(isdefined(mod, Symbol("@xx")))
       end
false
true

julia> isdefined(mod, Symbol("@xx"))
true

julia> let; global mod = Module()
           println(isdefined(mod, Symbol("@__MODULE__")))
           Core.eval(mod, :(macro __MODULE__() end))
           println(isdefined(mod, Symbol("@__MODULE__")))
       end
false # <- this used to return `true` on 1.11
false

julia> isdefined(mod, Symbol("@__MODULE__"))
true
```

which I believe was introduced by https://github.com/JuliaLang/julia/pull/57253. Invoking `isdefined` with `invokelatest` gives the correct answer.

This is a simple temporary fix, but perhaps this should be fixed upstream. cc @Keno