### PR TITLE
Don't construct `Module()` during precompilation

### DIFF
--- a/src/Infiltrator.jl
+++ b/src/Infiltrator.jl
@@ -191,6 +191,13 @@ mutable struct Session
   exiting::Bool
   disabled::Set
   conditions::Dict
+  function Session(exiting, disabled, conditions)
+    session = new()
+    session.exiting = exiting
+    session.disabled = disabled
+    session.conditions = conditions
+    session
+  end
 end
 function Base.show(io::IO, s::Session)
   n = length(get_store_names(s))
@@ -229,7 +236,7 @@ Also see [`clear_store!`](@ref), [`set_store!`](@ref), and [`@withstore`](@ref) 
 safehouse-related functionality.
 """
 @doc store_docstring
-const store = Session(Module(), false, Set(), Dict())
+const store = Session(false, Set(), Dict())
 @doc store_docstring
 const safehouse = store
 @doc store_docstring


### PR DESCRIPTION
A new error appeared for `nightly`, likely due to https://github.com/JuliaLang/julia/pull/57425:
```julia
Failed to precompile Infiltrator [5903a43b-9cc3-4c30-8d17-598619ec4e9b] to "/home/serenity4/julia/wip8/.julia/compiled/v1.13/Infiltrator/jl_KfVJ1M".
ERROR: LoadError: Creating a new global in closed module `anonymous` (`anonymous`) breaks incremental compilation because the side effects will not be permanent.
Stacktrace:
  [1] Module
    @ ./boot.jl:574 [inlined]
  [2] Module()
    @ Core ./boot.jl:574
  [3] top-level scope
    @ ~/julia/wip8/.julia/packages/Infiltrator/cxm1l/src/Infiltrator.jl:223
```

The created `Module()` was anyway discarded with `clear_store!(store)` during `__init__()`, so this change should be safe.