### PR TITLE
Do not use `clear_store!` during precompilation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Infiltrator"
 uuid = "5903a43b-9cc3-4c30-8d17-598619ec4e9b"
-version = "1.8.6"
+version = "1.8.7"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"


### PR DESCRIPTION
Caused by https://github.com/JuliaLang/julia/issues/57635, if in the future this issue is resolved in a way that allows for evaluation into closed modules during precompilation then we may revert this PR as well as #134.

#134 was not sufficient (see https://github.com/JuliaDebug/Infiltrator.jl/pull/134#issuecomment-2766420222) because `Infiltrator.__init__()` may still be called during precompilation by any package that loads Infiltrator, and this function mutates the store.

I further added a safeguard during access to `getfield(::Session, :store)` to make sure we correctly report any errors due to this new behavior.