### PR TITLE
Add prefix prompt

### DIFF
--- a/src/Infiltrator.jl
+++ b/src/Infiltrator.jl
@@ -758,9 +758,11 @@ function debugprompt(mod, locals, trace, terminal, repl, ex, bt; nostack = false
       return true
     end
 
-    panel.keymap_dict = LineEdit.keymap(Dict{Any,Any}[skeymap, LineEdit.history_keymap, LineEdit.default_keymap, LineEdit.escape_defaults])
+    prefix_prompt, prefix_keymap = LineEdit.setup_prefix_keymap(panel.hist, panel)
+    
+    panel.keymap_dict = LineEdit.keymap(Dict{Any,Any}[skeymap, prefix_keymap, LineEdit.history_keymap, LineEdit.default_keymap, LineEdit.escape_defaults])
 
-    REPL.run_interface(terminal, REPL.LineEdit.ModalInterface([panel, search_prompt]))
+    REPL.run_interface(terminal, REPL.LineEdit.ModalInterface([panel, prefix_prompt, search_prompt]))
   catch e
     e isa InterruptException || rethrow(e)
   end

--- a/test/generate.jl
+++ b/test/generate.jl
@@ -1,5 +1,6 @@
 for version in ["1.1", "1.6", "1.7", "1.8", "1.9", "1.10", "1.11", "1.12"]
     println("Generating outputs with Julia v$version")
-    rm(joinpath(@__DIR__, "..", "Manifest.toml"))
-    run(addenv(`julia +$version --project=$(dirname(@__DIR__)) -e 'using Pkg; Pkg.instantiate(); Pkg.test()'`, "INFILTRATOR_CREATE_TEST" => 1))
+    manifest_path = joinpath(@__DIR__, "..", "Manifest.toml")
+    isfile(manifest_path) && rm(manifest_path)
+    run(addenv(`julia +$version --startup-file=no --project=$(dirname(@__DIR__)) -e 'using Pkg; Pkg.instantiate(); Pkg.test()'`, "INFILTRATOR_CREATE_TEST" => 1))
 end

--- a/test/outputs/Julia_phist_1.1.multiout
+++ b/test/outputs/Julia_phist_1.1.multiout
@@ -1,0 +1,142 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+|
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+|
+|CCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+|
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+|
+|CCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB

--- a/test/outputs/Julia_phist_1.10.multiout
+++ b/test/outputs/Julia_phist_1.10.multiout
@@ -1,0 +1,142 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+|
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+|
+|CCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+|
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+|
+|CCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB

--- a/test/outputs/Julia_phist_1.11.multiout
+++ b/test/outputs/Julia_phist_1.11.multiout
@@ -1,0 +1,142 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+|
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+|
+|CCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+|
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+|
+|CCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB

--- a/test/outputs/Julia_phist_1.12.multiout
+++ b/test/outputs/Julia_phist_1.12.multiout
@@ -1,0 +1,142 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+|
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+|
+|CCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+|
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+|
+|CCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB

--- a/test/outputs/Julia_phist_1.6.multiout
+++ b/test/outputs/Julia_phist_1.6.multiout
@@ -1,0 +1,142 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+|
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+|
+|CCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+|
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+|
+|CCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB

--- a/test/outputs/Julia_phist_1.7.multiout
+++ b/test/outputs/Julia_phist_1.7.multiout
@@ -1,0 +1,142 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+|
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+|
+|CCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+|
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+|
+|CCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB

--- a/test/outputs/Julia_phist_1.8.multiout
+++ b/test/outputs/Julia_phist_1.8.multiout
@@ -1,0 +1,142 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+|
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+|
+|CCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+|
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+|
+|CCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB

--- a/test/outputs/Julia_phist_1.9.multiout
+++ b/test/outputs/Julia_phist_1.9.multiout
@@ -1,0 +1,142 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+|
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+|
+|CCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> x = 3
+|3
+|
+|infil> y = 1
+|1
+|
+|infil> 
+|
+|Infiltrating <unknown>
+|
+|infil> y = 1
+|1
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB
+|
+|CCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBBCCCCC
+|C
+|
+|BBBBBBB

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -148,7 +148,12 @@ end
         run_terminal_test((t) -> h([1,2,3]), [[3,4,5], [3,4,5], [3,4,5]],
                         ["\x4", "@locals\n", "@exit\n"],
                         "Julia_h_$(VERSION.major).$(VERSION.minor).multiout")
-
+                        
+        # Test that history is correctly using prefixes.
+        run_terminal_test((t) -> h([1,2,3]), [[3,4,5], [3,4,5], [3,4,5]],
+                        ["y = 1\n", "x = 3\n", "y\e[A\n", "\x4", "y\e[A\n", "@exit\n"],
+                        "Julia_phist_$(VERSION.major).$(VERSION.minor).multiout")
+                        
         run_terminal_test((t) -> i(1000), i(1000),
                         ["2+2\n", "@locals\n", "\x4"],
                         "Julia_i_$(VERSION.major).$(VERSION.minor).multiout")


### PR DESCRIPTION
This imitates what is done for `Base`. It creates a meta-prompt around the existing `Infiltrator` one and allow to go through history via the prefix.

```
julia> @infiltrate
Infiltrating top-level frame

infil> x = 2
2

infil> y = 3
3

infil>x # Press up arrow.

infil> x = 2 # x = 2 is directly fetched.
```