### PR TITLE
Adjust `print_response` workaround to minor REPL refactor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Infiltrator"
 uuid = "5903a43b-9cc3-4c30-8d17-598619ec4e9b"
-version = "1.8.9"
+version = "1.8.10"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/src/Infiltrator.jl
+++ b/src/Infiltrator.jl
@@ -861,8 +861,10 @@ end
 # on the REPL backend already, so that would cause a deadlock. Luckily we can pass
 # nothing instead of the actual REPL backend to work around that.
 @static if hasmethod(REPL.print_response, (IO, Any, Nothing, Bool, Bool, Union{AbstractDisplay,Nothing})) &&
-           isdefined(REPL, :eval_with_backend) &&
-           hasmethod(REPL.eval_with_backend, (Any, Nothing))
+           (isdefined(REPL, :eval_with_backend) &&
+            hasmethod(REPL.eval_with_backend, (Any, Nothing)) ||
+           (isdefined(REPL, :call_on_backend) &&
+            hasmethod(REPL.call_on_backend, (Any, Nothing))))
 
   function print_response(repl, response, show_value, have_color)
     repl.waserror = response[2]


### PR DESCRIPTION
The workaround introduced in #139 broke with https://github.com/JuliaLang/julia/pull/58414.

It would be nice to have a more reliable way to do it, but for now we can just hope it breaks very rarely.