### PR TITLE
fix: make `import X as Y` work on 1.12

### DIFF
--- a/src/Infiltrator.jl
+++ b/src/Infiltrator.jl
@@ -946,7 +946,11 @@ function all_names(m)
 end
 function all_names(m, pred, symbols = Set(Symbol[]), seen = Set(Module[]))
     push!(seen, m)
-    ns = names(m; all = true, imported = true)
+    ns = if VERSION > v"1.12-"
+        names(m; all = true, imported = true, usings = true)
+    else
+        names(m; all = true, imported = true)
+    end
 
     for n in ns
         isdefined(m, n) || continue

--- a/test/outputs/1.12/importas.multiout
+++ b/test/outputs/1.12/importas.multiout
@@ -1,0 +1,42 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> I
+|Infiltrator
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBC
+|CCCCCCCCCCC
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> I
+|Infiltrator
+|
+|infil> I.all_names
+|all_names (generic function with 4 methods)
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBC
+|CCCCCCCCCCC
+|
+|BBBBBBBCCCCCCCCCCC
+|CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+|
+|BBBBBBB

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,6 +86,17 @@ function globalref(m, s)
     return gr
 end
 
+module Asdf
+
+    using ..Infiltrator: Infiltrator as I, @infiltrate
+
+    function f(x)
+        @infiltrate
+        return x
+    end
+
+end
+
 @static if Sys.isunix()
     using TerminalRegressionTests
 
@@ -103,6 +114,7 @@ end
         test_func = TerminalRegressionTests.automated_test
         if haskey(ENV, "INFILTRATOR_CREATE_TEST") && !haskey(ENV, "CI")
             test_func = TerminalRegressionTests.create_automated_test
+            @info "Generating regression test outputs for $testname"
         end
 
         test_func(testpath, commands) do emuterm
@@ -291,6 +303,15 @@ end
             ["x = 1; for i in 1:5; x = i; end\n", "x\n", "\x4"],
             "soft"
         )
+
+        # import as, only works on 1.12
+        if VERSION > v"1.12-"
+            run_terminal_test(
+                (t) -> Asdf.f(1), 1,
+                ["I\n", "I.all_names\n", "\x4"],
+                "importas"
+            )
+        end
     end
 
     @testset "infiltry" begin


### PR DESCRIPTION
Fixes https://github.com/JuliaDebug/Infiltrator.jl/issues/106.