### PR TITLE
fix: dictionary key tab completion

### DIFF
--- a/src/Infiltrator.jl
+++ b/src/Infiltrator.jl
@@ -1216,17 +1216,11 @@ end
 end
 
 function completions(c::InfiltratorCompletionProvider, full, partial)
-    # repl backend completions
-    comps, range, should_complete = REPL.REPLCompletions.completions(full, lastindex(partial), c.mod)
-    ret = map(_completion_text, comps)
-
-    # completions for local variables
+    # localmod already contains locals, safehouse, and module variables merged
+    # Use it as the primary completion source to preserve context-sensitive completions
+    # (e.g., dictionary keys, which require evaluating the dict expression)
     comps, range, should_complete = REPL.REPLCompletions.completions(full, lastindex(partial), c.localmod)
-    prepend!(ret, map(_completion_text, comps))
-
-    # completions for safehouse variables
-    comps, range, should_complete = REPL.REPLCompletions.completions(full, lastindex(partial), get_store(store))
-    prepend!(ret, map(_completion_text, comps))
+    ret = map(_completion_text, comps)
 
     # Infiltrator commands completions
     commands = ["?", "@trace", "@trace_all", "@locals", "@toggle", "@exit", "@continue", "@exfiltrate", "@exception"]

--- a/test/outputs/1.10/dict_completion.multiout
+++ b/test/outputs/1.10/dict_completion.multiout
@@ -1,0 +1,28 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> d["a
+|"a very long key"
+|"another key"
+|infil> d["a very long key"]
+|true
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCC
+|CCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCC
+|BBBBBBBCCCCCCCCCCCCCCCCCCCC
+|CCCC
+|
+|BBBBBBB

--- a/test/outputs/1.11/dict_completion.multiout
+++ b/test/outputs/1.11/dict_completion.multiout
@@ -1,0 +1,28 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> d["a
+|"a very long key"
+|"another key"
+|infil> d["a very long key"]
+|true
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCC
+|CCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCC
+|BBBBBBBCCCCCCCCCCCCCCCCCCCC
+|CCCC
+|
+|BBBBBBB

--- a/test/outputs/1.12/dict_completion.multiout
+++ b/test/outputs/1.12/dict_completion.multiout
@@ -1,0 +1,28 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> d["a
+|"a very long key"
+|"another key"
+|infil> d["a very long key"]
+|true
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCC
+|CCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCC
+|BBBBBBBCCCCCCCCCCCCCCCCCCCC
+|CCCC
+|
+|BBBBBBB

--- a/test/outputs/1.13/dict_completion.multiout
+++ b/test/outputs/1.13/dict_completion.multiout
@@ -1,0 +1,28 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> d["a
+|"a very long key"
+|"another key"
+|infil> d["a very long key"]
+|true
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCC
+|CCCCCCCCCCCCCCCCC
+|CCCCCCCCCCCCC
+|BBBBBBBCCCCCCCCCCCCCCCCCCCC
+|CCCC
+|
+|BBBBBBB

--- a/test/outputs/1.6/dict_completion.multiout
+++ b/test/outputs/1.6/dict_completion.multiout
@@ -1,0 +1,26 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> d["a
+|"a very long key" "another key"
+|infil> d["a very long key"]
+|true
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCC
+|CCCCCCCCCCCCCCCCCACCCCCCCCCCCCC
+|BBBBBBBCCCCCCCCCCCCCCCCCCCC
+|CCCC
+|
+|BBBBBBB

--- a/test/outputs/1.7/dict_completion.multiout
+++ b/test/outputs/1.7/dict_completion.multiout
@@ -1,0 +1,26 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> d["a
+|"a very long key" "another key"
+|infil> d["a very long key"]
+|true
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCC
+|CCCCCCCCCCCCCCCCCACCCCCCCCCCCCC
+|BBBBBBBCCCCCCCCCCCCCCCCCCCC
+|CCCC
+|
+|BBBBBBB

--- a/test/outputs/1.8/dict_completion.multiout
+++ b/test/outputs/1.8/dict_completion.multiout
@@ -1,0 +1,26 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> d["a
+|"a very long key"  "another key"
+|infil> d["a very long key"]
+|true
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCC
+|CCCCCCCCCCCCCCCCCAACCCCCCCCCCCCC
+|BBBBBBBCCCCCCCCCCCCCCCCCCCC
+|CCCC
+|
+|BBBBBBB

--- a/test/outputs/1.9/dict_completion.multiout
+++ b/test/outputs/1.9/dict_completion.multiout
@@ -1,0 +1,26 @@
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBB
+++++++++++++++++++++++++++++++++++++++++++++++++++
+|Infiltrating <unknown>
+|
+|infil> d["a
+|"a very long key"  "another key"
+|infil> d["a very long key"]
+|true
+|
+|infil> 
+--------------------------------------------------
+|AAAAAAAAAAAAAAAAAAAAAA
+|
+|BBBBBBBCCCC
+|CCCCCCCCCCCCCCCCCAACCCCCCCCCCCCC
+|BBBBBBBCCCCCCCCCCCCCCCCCCCC
+|CCCC
+|
+|BBBBBBB

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -356,6 +356,19 @@ end
             ["a\n", "Shadow.a\n", "\x4"],
             "shadowing of global bindings"
         )
+
+        # dictionary key completion test
+        function dict_test()
+            d = Dict("a very long key" => true, "another key" => false)
+            @infiltrate
+            return d
+        end
+
+        run_terminal_test(
+            (t) -> dict_test(), Dict("a very long key" => true, "another key" => false),
+            ["d[\"a\t\t\n", "\x4"],
+            "dict_completion"
+        )
     end
 
     @testset "infiltry" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -356,19 +356,6 @@ end
             ["a\n", "Shadow.a\n", "\x4"],
             "shadowing of global bindings"
         )
-
-        # dictionary key completion test
-        function dict_test()
-            d = Dict("a very long key" => true, "another key" => false)
-            @infiltrate
-            return d
-        end
-
-        run_terminal_test(
-            (t) -> dict_test(), Dict("a very long key" => true, "another key" => false),
-            ["d[\"a\t\t\n", "\x4"],
-            "dict_completion"
-        )
     end
 
     @testset "infiltry" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -366,7 +366,7 @@ end
 
         run_terminal_test(
             (t) -> dict_test(), Dict("a very long key" => true, "another key" => false),
-            ["d[\"a\t\t\n", "\x4"],
+            ["d[\"a\t\t \t\n", "\x4"],
             "dict_completion"
         )
     end


### PR DESCRIPTION
Fixes #153

## Summary
- Fix dictionary key tab completion by consolidating redundant REPL completion calls
- The completion function called REPL completions three times, overwriting range/should_complete each time
- Now uses only localmod completions, which already contain merged scopes

## Test plan
- [x] Manual verification of dictionary key completion in Infiltrator REPL
- [x] Existing test suite passes